### PR TITLE
Limit index name length to 63; psql NAMEDATALEN-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ## About ##
 =====
 
-acts_as_versioned is a gem for Rails 3.1 & 3.2 to enable easy versioning of models. As a versioned model is updated revisions are kept in a seperate table, providing a record of what changed.
+acts_as_versioned is a gem for Rails 3.1, 3.2 & 4 to enable easy versioning of models. As a versioned model is updated revisions are kept in a seperate table, providing a record of what changed.
 
 ## Getting Started ##
 =====
 
 In your Gemfile simply include:
 
-    gem 'acts_as_versioned', :git => 'https://github.com/jwhitehorn/acts_as_versioned.git'
+    gem 'acts_as_versioned', :git => 'https://github.com/mjsommer/acts_as_versioned.git'
     
 The next time you run `bundle install` you'll be all set to start using acts_as_versioned.  
 

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -450,7 +450,9 @@ module ActiveRecord #:nodoc:
                                          :precision => type_col.precision
             end
 
-            self.connection.add_index versioned_table_name, versioned_foreign_key
+            # Limit index name length to 63, the Postgresql limit of NAMEDATALEN-1.
+            name = 'index_' + versioned_table_name + '_on_' + versioned_foreign_key
+            self.connection.add_index versioned_table_name, versioned_foreign_key, :name => name[0,63]
           end
 
           # Rake migration task to drop the versioned table


### PR DESCRIPTION
Hi Jason, I ran into an issue with generated index names being too long, and found this solution proposed by Ward Vandewege to technoweenie in 2011. I tested the code in my own build (Rails 4 / Postgres 9), and it works well. 

Can you please pull it in?

Thanks again,
Martin

Ref: https://github.com/technoweenie/acts_as_versioned/issues/9
